### PR TITLE
permeability: support for functors and material properties

### DIFF
--- a/include/OpalinusPermeabilityTensor.h
+++ b/include/OpalinusPermeabilityTensor.h
@@ -39,10 +39,11 @@ protected:
   const Real _permeability2;
   const Real _permeability3;
 
-  /// prefactor function to multiply the permeability tensor with
-  const Function * const _prefactor_function;
+  /// prefactor functor and material property to multiply the permeability tensor with
+  const Moose::Functor<Real> * const _prefactor_functor;
+  const MaterialProperty<Real> * const _prefactor_matprop;
 
-  /// Quadpoint permeability
+  /// quadpoint permeability
   MaterialProperty<RealTensorValue> & _permeability_qp;
 
   /// d(quadpoint permeability)/d(PorousFlow variable)

--- a/src/OpalinusPermeabilityTensor.C
+++ b/src/OpalinusPermeabilityTensor.C
@@ -46,9 +46,13 @@ OpalinusPermeabilityTensor::validParams()
       "than this permeability controls flow normal to this bedding "
       "(in this case for Opalinus, this corresponds to permeability of the S-samples)");
 
-  params.addParam<FunctionName>(
-      "permeability_tensor_prefactor",
-      "Optional function to use as a scalar prefactor on the permeability tensor.");
+  params.addParam<MooseFunctorName>(
+      "prefactor_functor",
+      "Optional functor to use as a scalar prefactor on the permeability tensor.");
+
+  params.addParam<MaterialPropertyName>(
+      "prefactor_mat_prop",
+      "Optional material property to use as a scalar prefactor on the permeability tensor.");
 
   return params;
 }
@@ -60,8 +64,11 @@ OpalinusPermeabilityTensor::OpalinusPermeabilityTensor(const InputParameters & p
     _permeability1(parameters.get<Real>("permeability1")),
     _permeability2(parameters.get<Real>("permeability2")),
     _permeability3(parameters.get<Real>("permeability3")),
-    _prefactor_function(isParamValid("permeability_tensor_prefactor")
-                            ? &getFunction("permeability_tensor_prefactor")
+    _prefactor_functor(isParamValid("prefactor_functor")
+                            ? &getFunctor<Real>("prefactor_functor")
+                            : nullptr),
+    _prefactor_matprop(isParamValid("prefactor_mat_prop")
+                            ? &getMaterialProperty<Real>("prefactor_mat_prop")
                             : nullptr),
     _permeability_qp(declareProperty<RealTensorValue>("PorousFlow_permeability_qp")),
     _dpermeability_qp_dvar(
@@ -79,9 +86,25 @@ OpalinusPermeabilityTensor::OpalinusPermeabilityTensor(const InputParameters & p
 void
 OpalinusPermeabilityTensor::computeQpProperties()
 {
-  if (_prefactor_function)
+  if (_prefactor_functor || _prefactor_matprop)
   {
-    _permeability_qp[_qp] = _input_permeability * _prefactor_function->value(_t, _q_point[_qp]);
+    Real f;
+
+    if (_prefactor_functor)
+    {
+      const Moose::ElemQpArg elem_arg{_current_elem, _qp, _qrule, _q_point[_qp]};
+      const auto state = determineState();
+      f = (*_prefactor_functor)(elem_arg, state);
+    }
+    else
+      f = 1.0;
+
+    if (_prefactor_matprop && f != 0.0)
+    {
+      f *= (*_prefactor_matprop)[_qp];
+    }
+
+    _permeability_qp[_qp] = _input_permeability * f;
   }
   else
     _permeability_qp[_qp] = _input_permeability;

--- a/test/tests/opalinus/HM_tunnel_x.i
+++ b/test/tests/opalinus/HM_tunnel_x.i
@@ -466,7 +466,7 @@ active_block_names = '${RockVolumes} ${TunnelVolumes}'
     permeability1 = 1e-19
     permeability2 = 1e-19
     permeability3 = 1e-21
-    permeability_tensor_prefactor = tunnel01_permeability_prefactor
+    prefactor_functor = tunnel01_permeability_prefactor
     local_coordinate_system = 'ucsOpalinusMaterial'
   []
 
@@ -488,7 +488,7 @@ active_block_names = '${RockVolumes} ${TunnelVolumes}'
     permeability1 = 1e-19
     permeability2 = 1e-19
     permeability3 = 1e-21
-    #permeability_tensor_prefactor = permeability_prefactor_method1
+    #prefactor_functor = permeability_prefactor_method1
     local_coordinate_system = 'ucsOpalinusMaterial'
   []
 


### PR DESCRIPTION
closes #24

The existing prefactor parameter in `OpalinusPermeabilityTensor` is *very* handy to control permeability from a modelling point of view. Reasons to do so include:
- Disturbance of the rock near the working face
- Modelling of increased permeability due to plastic strain

To simplify the input files of simulations modelling both effects listed above, it would preferable to use functors (as a widening of the existing support for functions) **and** material properties  at the same time. 

As indicated by https://github.com/idaholab/moose/discussions/30283, this cannot be implemented with one property in a simple way.

Therefore, this PR proposes the following solution:

- The existing (optional) parameter `permeability_tensor_prefactor` of type `FunctionName` is changed to type `MooseFunctorName` and renamed to `prefactor_functor`. The parameter remains optional. With this change, the current functionality is 100% covered (only the parameter name of existing Moose input files must be changed). In addition, all [functors](https://mooseframework.inl.gov/syntax/Functors/index.html) can now be used (not only functions)

- A new optional parameter `prefactor_mat_prop` of type `MaterialPropertyName` is added to `OpalinusPermeabilityTensor`.

- Both parameters may be used at the same time (then multiplied by each other). Or just one of the parameters. Or none of them.

This allows input file blocks looking like:
```
  [tunnel04_permeability_bulk]
    type = OpalinusPermeabilityTensor
    block = '${Mesh/tunnel04}'
    local_coordinate_system = 'ucsOpalinusMaterial'
    permeability1 = '${permeability1}'
    permeability2 = '${permeability2}'
    permeability3 = '${permeability3}'
    prefactor_functor = 'tunnel04_permeability_bulk_prefactor' # tunnel04_permeability_bulk_prefactor is a function defined in [Functions]
    prefactor_mat_prop = 'PermeabilityFactorFromPlasticStrain' # PermeabilityFactorFromPlasticStrain is a material parameter e.g. of type ParsedMaterial
  []
```

Performance Impact: 
- Using Functors for prefactor_functor should have a negligible performance impact.
- The new parameter prefactor_mat_prop should have a negligible performance impact.

Impact on existing input files
- the parameter name `permeability_tensor_prefactor` must be changed to `prefactor_functor`